### PR TITLE
fix: line height overridden by Font size

### DIFF
--- a/src/style-hook.ts
+++ b/src/style-hook.ts
@@ -215,8 +215,8 @@ export function useTextStyle(props: TextStyleProps | undefined = {}) {
     () =>
       [
         getTextColor?.(textColor as string),
-        LINE_HEIGHT[lineHeight as LineHeight],
         FONT_SIZE[fontSize as FontSize],
+        LINE_HEIGHT[lineHeight as LineHeight],
       ].filter(i => i != null),
     [textColor, fontSize, getTextColor, lineHeight],
   )


### PR DESCRIPTION
As `FONT_SIZE` by default provides a line height, 
an explicitly provided line height gets overridden. 