### PR TITLE
fix: skip removeEvetlistener call if subscription is available

### DIFF
--- a/src/theme-provider.tsx
+++ b/src/theme-provider.tsx
@@ -102,8 +102,9 @@ export function ThemeProvider({
     return () => {
       if (subscription?.remove) {
         return subscription.remove()
+      } else {
+        AppState.removeEventListener('change', calculateTheme)
       }
-      AppState.removeEventListener('change', calculateTheme)
     }
   }, [autoSwitchTheme, themes.dark, themes.light])
 


### PR DESCRIPTION
## Description

This PR fixes the below  warning 
`EventEmitter.removeListener('appStateDidChange', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`. `